### PR TITLE
Fix typo in fonts file path (unversioned)

### DIFF
--- a/versions/unversioned/sdk/font.md
+++ b/versions/unversioned/sdk/font.md
@@ -19,7 +19,7 @@ Convenience form of [`Expo.Font.loadAsync()`](#expofontloadasync "Expo.Font.load
 ```javascript
 Expo.Font.loadAsync({
   Montserrat: require('./assets/fonts/Montserrat.ttf'),
-  'Montserrat-SemiBold': require('./assets/fontsMontserrat-SemiBold.ttf'),
+  'Montserrat-SemiBold': require('./assets/fonts/Montserrat-SemiBold.ttf'),
 });
 ```
 


### PR DESCRIPTION
<!--
Thanks for helping! Please check that you have edited the docs in the
`versions/unversioned` directory, if you want these changes to apply to
the next SDK version too.
-->
